### PR TITLE
chore(readme): use urls

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # diagrams-ts
 
-![logo](generated-assets/logo-small.png)
+![logo](https://github.com/balles/diagrams-ts/raw/main/generated-assets/logo-small.png)
 
 Monorepository for `TypeScript`-Port of the python library [`diagrams` by mingrammer](https://diagrams.mingrammer.com/).
 Creating architecture diagrams directly from code.

--- a/packages/diagrams-ts/README.md
+++ b/packages/diagrams-ts/README.md
@@ -1,6 +1,6 @@
 # diagrams-ts
 
-![logo](../../generated-assets/logo-small.png)
+![logo](https://github.com/balles/diagrams-ts/raw/main/generated-assets/logo-small.png)
 
 `TypeScript`-Port of the python library [`diagrams` by mingrammer](https://diagrams.mingrammer.com/).
 Creating architecture diagrams directly from code.
@@ -78,7 +78,7 @@ const awsFlow = () => {
 
 If you'll run it will create the "aws-flow.png" in the output folder:
 
-![AWS Flow diagram](../../generated-assets/aws-flow.png)
+![AWS Flow diagram](https://github.com/balles/diagrams-ts/raw/main/generated-assets/aws-flow.png)
 
 For more examples of the syntax you can take look at the examples folder. In order to run them, you can use `ts-node` e.g.:
 


### PR DESCRIPTION
Use URLs so that README contains images outside of github.